### PR TITLE
Fix FYEO audit findings (FYEO-EXO-01, FYEO-EXO-02)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,6 +1737,7 @@ dependencies = [
  "solana-vote",
  "solana-vote-program",
  "spl-stake-pool",
+ "tempfile",
  "tip-router-operator-cli",
  "tokio",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,3 +27,6 @@ borsh = { version = "0.10.3" }
 gov-v1 = { path = "../programs/gov-v1" }
 spl-stake-pool = { version = "2.0.0", default-features = false, features = ["no-entrypoint"] }
 borsh_stake = { package = "borsh", version = "1.5", default-features = false }
+
+[dev-dependencies]
+tempfile = "3"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -636,6 +636,10 @@ fn main() -> Result<()> {
                         fs::copy(full_path, &dest_full)?;
                         fs::copy(&incr_path, &dest_incr)?;
 
+                        // Validate paths before executing external binary
+                        validate_executable_path(&agave_ledger_tool_path)?;
+                        validate_directory_path(&ledger_path)?;
+
                         // Run agave-ledger-tool to copy ledger into backup directory
                         let end_copy_slot = slot.saturating_add(32);
                         info!(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -540,6 +540,10 @@ fn main() -> Result<()> {
             ledger_path,
             generate_meta_merkle,
         } => {
+            // Validate paths upfront before entering the scan loop
+            validate_executable_path(&agave_ledger_tool_path)?;
+            validate_directory_path(&ledger_path)?;
+
             info!(
                 "AwaitSnapshot starting: scan_interval={}m target_slot={} snapshot_dir={:?} backup_snapshot_dir={:?} backup_ledger_dir={:?}",
                 scan_interval,
@@ -635,10 +639,6 @@ fn main() -> Result<()> {
                         fs::create_dir_all(&backup_snapshots_dir)?;
                         fs::copy(full_path, &dest_full)?;
                         fs::copy(&incr_path, &dest_incr)?;
-
-                        // Validate paths before executing external binary
-                        validate_executable_path(&agave_ledger_tool_path)?;
-                        validate_directory_path(&ledger_path)?;
 
                         // Run agave-ledger-tool to copy ledger into backup directory
                         let end_copy_slot = slot.saturating_add(32);

--- a/cli/src/utils/mod.rs
+++ b/cli/src/utils/mod.rs
@@ -1,7 +1,9 @@
 pub mod parsers;
+pub mod path;
 pub mod send_utils;
 pub mod io;
 
 pub use parsers::*;
+pub use path::*;
 pub use send_utils::*;
 pub use io::*;

--- a/cli/src/utils/path.rs
+++ b/cli/src/utils/path.rs
@@ -1,0 +1,166 @@
+use anyhow::{anyhow, Result};
+use std::fs;
+use std::path::Path;
+
+/// Validates that a path points to a regular, executable file (not a symlink).
+pub fn validate_executable_path(path: &Path) -> Result<()> {
+    let path_str = path.to_string_lossy();
+
+    if path_str.starts_with('-') {
+        return Err(anyhow!(
+            "Executable path must not start with '-': {}",
+            path_str
+        ));
+    }
+
+    let canonical = fs::canonicalize(path)
+        .map_err(|e| anyhow!("Failed to resolve executable path '{}': {}", path_str, e))?;
+
+    let metadata = fs::metadata(&canonical)
+        .map_err(|e| anyhow!("Failed to read metadata for '{}': {}", canonical.display(), e))?;
+
+    if !metadata.is_file() {
+        return Err(anyhow!(
+            "Executable path is not a regular file: {}",
+            canonical.display()
+        ));
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o111 == 0 {
+            return Err(anyhow!(
+                "File is not executable: {}",
+                canonical.display()
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Validates that a path points to an existing directory (not a symlink to one).
+pub fn validate_directory_path(path: &Path) -> Result<()> {
+    let path_str = path.to_string_lossy();
+
+    if path_str.starts_with('-') {
+        return Err(anyhow!(
+            "Directory path must not start with '-': {}",
+            path_str
+        ));
+    }
+
+    let canonical = fs::canonicalize(path)
+        .map_err(|e| anyhow!("Failed to resolve directory path '{}': {}", path_str, e))?;
+
+    let metadata = fs::metadata(&canonical)
+        .map_err(|e| anyhow!("Failed to read metadata for '{}': {}", canonical.display(), e))?;
+
+    if !metadata.is_dir() {
+        return Err(anyhow!(
+            "Path is not a directory: {}",
+            canonical.display()
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{self, File};
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn setup() -> TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    // --- validate_executable_path ---
+
+    #[test]
+    fn executable_rejects_dash_prefix() {
+        let result = validate_executable_path(Path::new("-malicious"));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("must not start with '-'"));
+    }
+
+    #[test]
+    fn executable_rejects_nonexistent() {
+        let result = validate_executable_path(Path::new("/no/such/binary"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn executable_rejects_directory() {
+        let dir = setup();
+        let result = validate_executable_path(dir.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not a regular file"));
+    }
+
+    #[test]
+    fn executable_rejects_non_executable_file() {
+        let dir = setup();
+        let file_path = dir.path().join("not_exec");
+        File::create(&file_path).unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&file_path, fs::Permissions::from_mode(0o644)).unwrap();
+        }
+
+        let result = validate_executable_path(&file_path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn executable_accepts_valid() {
+        let dir = setup();
+        let file_path = dir.path().join("good_bin");
+        File::create(&file_path).unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&file_path, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        assert!(validate_executable_path(&file_path).is_ok());
+    }
+
+    // --- validate_directory_path ---
+
+    #[test]
+    fn directory_rejects_dash_prefix() {
+        let result = validate_directory_path(Path::new("-bad"));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("must not start with '-'"));
+    }
+
+    #[test]
+    fn directory_rejects_nonexistent() {
+        let result = validate_directory_path(Path::new("/no/such/dir"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn directory_rejects_file() {
+        let dir = setup();
+        let file_path = dir.path().join("a_file");
+        File::create(&file_path).unwrap();
+
+        let result = validate_directory_path(&file_path);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not a directory"));
+    }
+
+    #[test]
+    fn directory_accepts_valid() {
+        let dir = setup();
+        assert!(validate_directory_path(dir.path()).is_ok());
+    }
+}

--- a/tests/src/test_full_program_flow.rs
+++ b/tests/src/test_full_program_flow.rs
@@ -604,7 +604,7 @@ fn test_reset_ballot_box(
 
     // Verify ballot box tallies is at max capacity, with only one operator vote
     let ballot_box: BallotBox = program.account(ballot_box_pda)?;
-    assert_eq!(ballot_box.ballot_tallies.len(), MAX_OPERATOR_VOTES);
+    assert_eq!(ballot_box.ballot_tallies.len(), MAX_BALLOT_TALLIES);
     assert_eq!(ballot_box.operator_votes.len(), 1);
 
     // Reset ballot box should succeed


### PR DESCRIPTION
## Summary

Addresses both informational findings from the FYEO security review (Nov 19, 2025).

- **FYEO-EXO-01**: Add path validation and canonicalization for user-supplied paths in the `AwaitSnapshot` CLI command before passing them to `Command::new`. Validates that `agave_ledger_tool_path` is a regular executable file and `ledger_path` is an existing directory. Rejects dash-prefixed paths to prevent argument injection.
- **FYEO-EXO-02**: Fix inconsistent constant usage — `ballot_tallies.len()` was being compared against `MAX_OPERATOR_VOTES` instead of `MAX_BALLOT_TALLIES` in the integration test.

## Test plan

- [x] `cargo test -p cli` — 9 new unit tests for path validation helpers pass
- [x] `anchor test -- --features skip-pda-check` — integration tests pass with constant fix